### PR TITLE
feat!: modernize gem for OpenAI Images API 2.0.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  push:
+    branches: [main, master, develop]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby-version: ["3.1", "3.2", "3.3"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby-version }}
+          bundler-cache: true
+      - name: Bundle install
+        run: bundle install
+      - name: RSpec
+        run: bundle exec rspec

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,44 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [2.0.0] - 2026-04-07
+
+### Added
+
+- `GenerateImage.configure` for global defaults (`api_key`, `default_model`, `base_url`, `default_size`, `default_quality`, `default_output_format`, timeouts, `max_retries`).
+- `GenerateImage::Client#generate` — `POST /v1/images/generations` with GPT Image models (`gpt-image-1`, `gpt-image-1.5`, `gpt-image-1-mini`) and DALL·E 2/3.
+- `GenerateImage::Client#edit` — `POST /v1/images/edits` with multipart uploads (`image`, optional `mask`).
+- `GenerateImage::Response` with `#url`, `#b64`, `#images`, `#usage`, `#model`, `#raw`, `#to_h` (legacy-shaped hash).
+- Error types: `AuthenticationError`, `RateLimitError`, `ApiError`, `ValidationError`; `RequestFailed` aliases `ApiError` for rescues.
+- Retries on HTTP 429 using `Retry-After` (up to `configuration.max_retries`).
+- RSpec suite with WebMock.
+
+### Changed
+
+- **Default model** is `gpt-image-1` (was DALL·E 2–era `image-alpha-001`).
+- **Default size** is `1024x1024` (was `512x512`).
+- Preferred API key env var is **`OPENAI_API_KEY`**; **`DALL_E_API_KEY`** remains a fallback.
+
+### Removed
+
+- Runtime dependencies on `sinatra`, `openai`, and pinned `json` / `net-http` (stdlib `net/http` + `json` only).
+
+### Deprecated
+
+- `Client#generate_image` — use `#generate`; emits a deprecation warning on stderr.
+
+### Migration
+
+- Replace `client.generate_image("prompt", opts)` with `client.generate("prompt", **opts)` and use `Response` (`#url` / `#b64`) or `#to_h` for a v1-like hash.
+
+---
+
+## [1.x]
+
+Earlier releases targeted the legacy Images API with DALL·E 2 defaults. OpenAI has announced sunset timelines for older image models; prefer GPT Image models in new code.
+
+[2.0.0]: https://github.com/merouaneamqor/generate_image/releases

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,25 @@
+# generate_image — AI assistant notes
+
+Ruby gem: **OpenAI Images API** client (`/v1/images/generations`, `/v1/images/edits`). Stdlib only (`Net::HTTP`, `json`). **Ruby >= 3.1**.
+
+## Layout
+
+| Path | Role |
+|------|------|
+| `lib/generate_image.rb` | Entry; `GenerateImage.configure` |
+| `lib/generate_image/client.rb` | `#generate`, `#edit`, deprecated `#generate_image` |
+| `lib/generate_image/http.rb` | JSON POST, multipart POST, 429 retry |
+| `lib/generate_image/configuration.rb` | Keys, defaults, timeouts |
+| `lib/generate_image/models.rb` | Model/size constants |
+| `lib/generate_image/response.rb` | Parsed API response |
+| `lib/generate_image/errors.rb` | Error hierarchy |
+
+## Conventions
+
+- Do not add heavy runtime deps; keep generation HTTP in `HTTP`, validation in `Client`.
+- Preserve backward compat: `DALL_E_API_KEY` fallback, `RequestFailed` alias, `#generate_image` delegation.
+- API key: never log or persist keys; read from config or env only.
+
+## Checks
+
+From gem root: `bundle install` then `bundle exec rspec`.

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,5 @@
+# frozen_string_literal: true
+
 source "https://rubygems.org"
 
-# Specify your gem's dependencies in generate_image.gemspec
 gemspec
-
-gem "rake", "~> 12.0"
-gem "rspec", "~> 3.0"

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2023 AMQOR Merouane
+Copyright (c) 2023-2026 AMQOR Merouane
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,85 +1,165 @@
 # GenerateImage
-The GenerateImage gem is a Ruby gem that provides an interface for generating images using the OpenAI DALL-E API. This gem can be used in Ruby on Rails projects or any other Ruby projects.
+
+Lightweight **Ruby** client for the **OpenAI Images API**: image generation (`POST /v1/images/generations`) and edits (`POST /v1/images/edits`). Uses only the standard library (`Net::HTTP`, `JSON`). **Ruby >= 3.1**.
+
+> **Deprecation / sunset (OpenAI):** DALL·E 2 and DALL·E 3 are scheduled for **sunset on May 12, 2026**. Prefer **GPT Image** models (`gpt-image-1`, `gpt-image-1.5`, `gpt-image-1-mini`) for new integrations. This gem defaults to `gpt-image-1`.
 
 ## Installation
-Add this line to your application's Gemfile:
 
-    gem 'generate_image'
+Add to your Gemfile:
 
-And then execute:
+```ruby
+gem "generate_image", "~> 2.0"
+```
 
-    bundle install
+Then:
 
-Or install it directly by running:
+```bash
+bundle install
+```
 
-    gem install generate_image
+## Configuration
+
+Set **`OPENAI_API_KEY`** (recommended). The legacy **`DALL_E_API_KEY`** is still read as a fallback if `OPENAI_API_KEY` is unset.
+
+Optional global defaults:
+
+```ruby
+require "generate_image"
+
+GenerateImage.configure do |c|
+  c.api_key = ENV["OPENAI_API_KEY"]
+  c.default_model = "gpt-image-1"
+  c.base_url = "https://api.openai.com"
+  c.default_size = "1024x1024"
+  c.default_quality = "auto"
+  c.default_output_format = "png"
+  c.open_timeout = 30
+  c.read_timeout = 120
+  c.max_retries = 1 # extra attempts after HTTP 429, honors Retry-After
+end
+```
+
+You can also pass an API key per client: `GenerateImage::Client.new("sk-...")`.
+
 ## Usage
-The gem provides a generate_image method, which takes a text argument and returns the generated image URL or image base64 as a hash. The method makes a request to the DALL-E API to generate an image based on the provided text.
 
-Before using the generate_image method, you must set your OpenAI API key as an environment variable named `DALL_E_API_KEY`. The gem uses the `Net::HTTP` library to make API requests and includes error handling to ensure successful image generation. In case of any errors, the method will raise a RequestFailed exception.
+### Generate (GPT Image)
 
-### Examples
+```ruby
+client = GenerateImage::Client.new
 
-    require 'generate_image'
+response = client.generate("A ruby gemstone on velvet, product photo")
 
-    # Set the DALL-E API key
-    ENV['DALL_E_API_KEY'] = 'your_api_key'
+response.b64        # first image base64 (typical for GPT Image)
+response.url        # first HTTPS URL when API returns URLs
+response.images     # => [{ b64_json: "..." }] or [{ url: "..." }], ...
+response.usage      # token usage hash or nil
+response.model      # model used
+response.raw        # full parsed JSON Hash
+```
 
-    # Generate a single image with default options
-    result = GenerateImage.generate_image('A three-story castle made of ice cream')
-    if result[:error]
-      puts result[:error]
-    else
-      puts result[:image_url]
-    end
+Common options (passed as keyword args):
 
-    # Generate a single image with custom options
-    result = GenerateImage.generate_image('A cat playing the piano', model: 'image-alpha-001', num_images: 2, size: '1024x1024', response_format: 'base64', quality: 90)
-    if result[:error]
-      puts result[:error]
-    else
-      puts result[:image_base64]
-    end
-## Options
-The generate_image method accepts a hash of options to customize the generated images. Here are the available options:
+| Option | GPT Image | DALL·E 3 |
+|--------|-----------|----------|
+| `model` | `gpt-image-1`, `gpt-image-1.5`, `gpt-image-1-mini` | `dall-e-3` |
+| `n` | 1–10 | 1 only |
+| `size` | `auto`, `1024x1024`, `1536x1024`, `1024x1536` | `1024x1024`, `1792x1024`, `1024x1792` |
+| `quality` | `auto`, `high`, `medium`, `low` | `standard`, `hd` |
+| `output_format` | `png`, `jpeg`, `webp` | (API returns URLs by default; use `response_format`) |
+| `background` | `transparent`, `opaque`, `auto` | — |
+| `response_format` | `url`, `b64_json` if you need to force format | often `url` |
 
-`model` - The name of the model to use for generating the images. Default is `image-alpha-001`.
+```ruby
+client.generate(
+  "Minimal logo",
+  model: "gpt-image-1-mini",
+  size: "1024x1024",
+  quality: "high",
+  output_format: "png",
+  background: "transparent",
+  n: 2
+)
+```
 
-`num_images` - The number of images to generate. Default is `1`.
+### Generate (DALL·E 3)
 
-`size` - The dimensions of the generated images in the format widthxheight. Default is `512x512`.
+```ruby
+client.generate(
+  "Sunset over the Atlantic",
+  model: "dall-e-3",
+  size: "1792x1024",
+  quality: "hd",
+  response_format: "url"
+)
+```
 
-`response_format` - The format of the response, either `url` or `base64`. Default is `url`.
+### Edit / inpainting
 
-`style` - The model or style to use for generating the images. Default is `nil`, which uses the default style of the selected model.
+Multipart request with at least **`image:`** (path string, `Pathname`, `IO`, or `StringIO`) and **`prompt:`**.
 
-`scale` - The scaling factor for the generated image. Default is `1`.
+```ruby
+client.edit(
+  image: "input.png",
+  prompt: "Add soft studio lighting",
+  model: "gpt-image-1",
+  size: "1024x1024",
+  quality: "auto",
+  mask: "mask.png" # optional
+)
+```
 
-`seed` - The random seed to use for the generation process. Default is `nil`.
+Additional GPT Image–oriented options: `output_format`, `background`, `input_fidelity` (`high` / `low`), `response_format`, `user`.
 
-`quality` - The JPEG compression quality of the generated image. Default is `80`.
+### Errors
 
-`text_model` - The name of the model to use for generating text prompts. Default is `text-davinci-002`.
+| Exception | When |
+|-----------|------|
+| `GenerateImage::AuthenticationError` | 401 / missing API key |
+| `GenerateImage::RateLimitError` | 429 (retried according to `max_retries` and `Retry-After`) |
+| `GenerateImage::ApiError` | Other non-success HTTP responses (`#status_code`, `#body`) |
+| `GenerateImage::ValidationError` | Invalid prompt, model/size/n combination, etc. |
 
-`text_prompt` - The text prompt to use for generating the image. Default is `nil`.
+`GenerateImage::RequestFailed` is an alias for `ApiError` for compatibility with rescues from v1.x.
 
-`text_length` - The maximum length of the generated text. Default is `nil`.
+## Backward compatibility (v1.x)
+
+- `client.generate_image(text, options_hash)` still works but **prints a deprecation warning** and returns a legacy-shaped `Hash` (`:image_url` or `:image_base64`) via `Response#to_h`.
+- Legacy keys: `num_images` → `n`, `response_format: "base64"` → `b64_json` for the API.
+
+Prefer:
+
+```ruby
+response = client.generate("A cat")
+response.url || response.b64
+```
+
+## Migration from 1.x
+
+1. Bump Ruby to **3.1+** and gem to **~> 2.0**.
+2. Set **`OPENAI_API_KEY`** (keep `DALL_E_API_KEY` temporarily if needed).
+3. Replace `generate_image(...)` with `generate(...)` and read `Response` fields instead of only a Hash.
+4. Update defaults mentally: model is **`gpt-image-1`**, size **`1024x1024`**, not DALL·E 2 `512x512` / `image-alpha-001`.
+5. Plan for **DALL·E 2/3 sunset (May 12, 2026)** — move prompts to GPT Image models.
 
 ## Development
-To contribute to the development of this gem, clone the repository and run the following commands to install dependencies and run tests:
 
-    bin/setup
-    rake spec
-You can also run bin/console for an interactive prompt to experiment with the code.
+```bash
+bundle install
+bundle exec rspec
+```
 
-To release a new version, update the version number in version.rb and run:
+Interactive console:
 
-    bundle exec rake release
-
-This will create a git tag for the new version, push the git commits and tags, and upload the .gem file to RubyGems.org.
+```bash
+bin/console
+```
 
 ## Contributing
-Bug reports and pull requests are welcome on the GitHub repository. This project is intended to be a safe and welcoming space for collaboration, and all contributors are expected to adhere to the code of conduct.
+
+Issues and pull requests are welcome on the [GitHub repository](https://github.com/merouaneamqor/generate_image).
 
 ## License
-The GenerateImage gem is open source software, released under the terms of the MIT License.
+
+MIT. See [LICENSE.txt](LICENSE.txt).

--- a/generate_image.gemspec
+++ b/generate_image.gemspec
@@ -1,27 +1,37 @@
-require_relative 'lib/generate_image/version'
+# frozen_string_literal: true
+
+require_relative "lib/generate_image/version"
 
 Gem::Specification.new do |spec|
-  spec.name          = "generate_image"
-  spec.version       = GenerateImage::VERSION
-  spec.authors       = ["AMQOR Merouane"]
-  spec.email         = ["marouane.amqor@gmail.com"]
+  spec.name = "generate_image"
+  spec.version = GenerateImage::VERSION
+  spec.authors = ["AMQOR Merouane"]
+  spec.email = ["marouaneamqor@gmail.com"]
 
-  spec.summary       = "Generate images using the DALL-E API"
-  spec.description   = "The 'generate_image' gem provides a simple and easy-to-use interface for generating images using the powerful DALL-E API from OpenAI. This Ruby gem can be used in Ruby on Rails projects or any other Ruby projects to create stunning images based on the text you provide. Unleash your imagination and generate images for any use case, from social media posts to marketing materials and beyond."
-  spec.homepage      = "https://github.com/merouaneamqor/generate_image"
-  spec.license       = "MIT"
-  spec.required_ruby_version = Gem::Requirement.new(">= 2.3.0")
+  spec.summary = "OpenAI Images API client (GPT Image, DALL·E) for Ruby"
+  spec.description = <<~DESC
+    Lightweight Ruby client for OpenAI image generation and edits (/v1/images/generations, /v1/images/edits).
+    Defaults to GPT Image models; stdlib-only (Net::HTTP + JSON). Ruby 3.1+.
+  DESC
+  spec.homepage = "https://github.com/merouaneamqor/generate_image"
+  spec.license = "MIT"
+  spec.required_ruby_version = ">= 3.1.0"
 
-  spec.add_dependency "net-http", "~> 0.3.2"
-  spec.add_dependency 'sinatra', "~> 3.0.5"
-  spec.add_dependency 'json', "~> 2.6.3"
-  spec.add_dependency 'openai', "~> 0.3.0"
+  spec.metadata["homepage_uri"] = spec.homepage
+  spec.metadata["source_code_uri"] = spec.homepage
+  spec.metadata["changelog_uri"] = "#{spec.homepage}/blob/main/CHANGELOG.md"
+  spec.metadata["rubygems_mfa_required"] = "true"
 
-  spec.files         = `git ls-files`.split($/)
-  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
-  spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
+  spec.files = Dir.chdir(__dir__) do
+    `git ls-files -z`.split("\x0").reject { |f| f.match(%r{\A(?:test|spec|features)/}) }
+  rescue StandardError
+    Dir["lib/**/*", "LICENSE.txt", "README.md", "CHANGELOG.md"]
+  end
+  spec.bindir = "exe"
+  spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
-  spec.files = Dir['lib/**/*', 'bin/*', 'LICENSE.txt', 'README.md']
-  spec.files -= Dir['generate_image-*.gem']
 
+  spec.add_development_dependency "rake", "~> 13.0"
+  spec.add_development_dependency "rspec", "~> 3.12"
+  spec.add_development_dependency "webmock", "~> 3.19"
 end

--- a/lib/generate_image.rb
+++ b/lib/generate_image.rb
@@ -1,46 +1,21 @@
-require 'net/http'
-require 'json'
+# frozen_string_literal: true
+
+require_relative "generate_image/version"
+require_relative "generate_image/errors"
+require_relative "generate_image/configuration"
+require_relative "generate_image/models"
+require_relative "generate_image/response"
+require_relative "generate_image/http"
+require_relative "generate_image/client"
 
 module GenerateImage
-  class RequestFailed < StandardError; end
-
-  class Client
-    API_ENDPOINT = 'https://api.openai.com/v1/images/generations'
-
-    def initialize(api_key = nil)
-      @api_key = api_key || ENV['DALL_E_API_KEY']
+  class << self
+    def configuration
+      @configuration ||= Configuration.new
     end
 
-    def generate_image(text, options = {})
-      unless @api_key
-        raise StandardError, "API Key not set"
-      end
-      uri = URI(API_ENDPOINT)
-      request = Net::HTTP::Post.new(uri)
-      request['Content-Type'] = 'application/json'
-      request['Authorization'] = "Bearer #{@api_key}"
-      request.body = {
-        prompt: text,
-        n: options[:num_images] || 1,
-        size: options[:size] || '512x512',
-        response_format: options[:response_format] || 'url',
-      }.to_json
-
-      response = Net::HTTP.start(uri.hostname, uri.port, use_ssl: true) do |http|
-        http.request(request)
-      end
-
-      if response.code == '200'
-        if options[:response_format] == 'base64'
-          image_base64 = JSON.parse(response.body)['data'][0]['base64']
-          return { image_base64: image_base64 }
-        else
-          image_url = JSON.parse(response.body)['data'][0]['url']
-          return { image_url: image_url }
-        end
-      else
-        raise RequestFailed, "Failed to generate image. Response code: #{response.code}. Response body: #{response.body}"
-      end
+    def configure
+      yield configuration
     end
   end
 end

--- a/lib/generate_image/client.rb
+++ b/lib/generate_image/client.rb
@@ -1,0 +1,201 @@
+# frozen_string_literal: true
+
+require "delegate"
+
+module GenerateImage
+  class Client
+    DEPRECATE_GENERATE_IMAGE_MSG =
+      "[DEPRECATION] GenerateImage::Client#generate_image is deprecated; use #generate instead."
+
+    def initialize(api_key = nil)
+      @api_key_override = api_key
+    end
+
+    def generate(prompt, **opts)
+      raise ValidationError, "prompt must be a non-empty String" unless prompt.is_a?(String) && !prompt.strip.empty?
+
+      model = (opts[:model] || configuration.default_model).to_s
+      validate_generation_model!(model)
+
+      body = build_generation_body(prompt, model, opts)
+      parsed = http.post_json("/v1/images/generations", body)
+      Response.new(parsed, model: model)
+    end
+
+    def edit(image:, prompt:, **opts)
+      raise ValidationError, "prompt must be a non-empty String" unless prompt.is_a?(String) && !prompt.strip.empty?
+      raise ValidationError, "image is required" if image.nil?
+
+      model = (opts[:model] || configuration.default_model).to_s
+      validate_edit_model!(model)
+
+      fields = build_edit_fields(model, prompt, opts)
+      files = { "image" => image }
+      files["mask"] = opts[:mask] if opts[:mask]
+
+      parsed = http.post_multipart("/v1/images/edits", fields, files)
+      Response.new(parsed, model: model)
+    end
+
+    def generate_image(text, options = {})
+      warn "#{DEPRECATE_GENERATE_IMAGE_MSG}\n"
+      generate(text, **legacy_options_to_new(options)).to_h
+    end
+
+    private
+
+    def configuration
+      base = GenerateImage.configuration
+      if @api_key_override && !@api_key_override.to_s.strip.empty?
+        KeyOverride.new(base, @api_key_override)
+      else
+        base
+      end
+    end
+
+    def http
+      @http ||= HTTP.new(configuration: configuration)
+    end
+
+    def build_generation_body(prompt, model, opts)
+      cfg = configuration
+      n = (opts.key?(:n) ? opts[:n] : 1).to_i
+      size = (opts[:size] || cfg.default_size).to_s
+
+      validate_generation_n!(model, n)
+      validate_generation_size!(model, size)
+
+      body = {
+        prompt: prompt,
+        model: model,
+        n: n,
+        size: size
+      }
+
+      if Models.gpt_image?(model)
+        body[:quality] = (opts[:quality] || cfg.default_quality).to_s
+        of = opts[:output_format] || cfg.default_output_format
+        body[:output_format] = of.to_s if of && !of.to_s.empty?
+        body[:background] = opts[:background].to_s if opts[:background]
+        body[:response_format] = opts[:response_format].to_s if opts[:response_format]
+        body[:style] = opts[:style].to_s if opts[:style]
+      elsif Models.dall_e_3?(model)
+        body[:quality] = (opts[:quality] || "standard").to_s
+        body[:response_format] = (opts[:response_format] || "url").to_s
+        body[:style] = opts[:style].to_s if opts[:style]
+      else
+        body[:response_format] = opts[:response_format].to_s if opts[:response_format]
+      end
+
+      body[:user] = opts[:user].to_s if opts[:user]
+      body.compact
+    end
+
+    def build_edit_fields(model, prompt, opts)
+      cfg = configuration
+      n = (opts.key?(:n) ? opts[:n] : 1).to_i
+      size = (opts[:size] || cfg.default_size).to_s
+
+      validate_generation_n!(model, n)
+      validate_generation_size!(model, size)
+
+      fields = {
+        "model" => model,
+        "prompt" => prompt,
+        "n" => n.to_s,
+        "size" => size
+      }
+
+      if Models.gpt_image?(model)
+        fields["quality"] = (opts[:quality] || cfg.default_quality).to_s
+        of = opts[:output_format] || cfg.default_output_format
+        fields["output_format"] = of.to_s if of && !of.to_s.empty?
+        fields["background"] = opts[:background].to_s if opts[:background]
+        fields["input_fidelity"] = opts[:input_fidelity].to_s if opts[:input_fidelity]
+        fields["response_format"] = opts[:response_format].to_s if opts[:response_format]
+      elsif Models.dall_e_3?(model)
+        fields["quality"] = (opts[:quality] || "standard").to_s
+        fields["response_format"] = (opts[:response_format] || "url").to_s
+      elsif opts[:response_format]
+        fields["response_format"] = opts[:response_format].to_s
+      end
+
+      fields["user"] = opts[:user].to_s if opts[:user]
+      fields.compact
+    end
+
+    def validate_generation_model!(model)
+      return if Models::ALL.include?(model)
+
+      raise ValidationError, "Unknown model #{model.inspect}. Expected one of: #{Models::ALL.join(", ")}"
+    end
+
+    def validate_edit_model!(model)
+      # Edits are supported for gpt-image and dall-e-2 historically; dall-e-3 may differ — allow gpt + dall-e-2 + dall-e-3 per API
+      return if Models.gpt_image?(model) || model == Models::DALLE2 || model == Models::DALLE3
+
+      raise ValidationError,
+            "Unsupported edit model #{model.inspect}. Use a GPT Image model, #{Models::DALLE2}, or #{Models::DALLE3}."
+    end
+
+    def validate_generation_n!(model, n)
+      raise ValidationError, "n must be between 1 and 10" unless n >= 1 && n <= 10
+
+      return unless Models.dall_e_3?(model)
+
+      raise ValidationError, "n must be 1 for #{model}" if n != 1
+    end
+
+    def validate_generation_size!(model, size)
+      valid =
+        if Models.gpt_image?(model)
+          Models::GPT_IMAGE_SIZES.include?(size)
+        elsif Models.dall_e_3?(model)
+          Models::DALLE3_SIZES.include?(size)
+        else
+          Models::DALLE2_SIZES.include?(size)
+        end
+
+      return if valid
+
+      allowed =
+        if Models.gpt_image?(model)
+          Models::GPT_IMAGE_SIZES
+        elsif Models.dall_e_3?(model)
+          Models::DALLE3_SIZES
+        else
+          Models::DALLE2_SIZES
+        end
+
+      raise ValidationError, "Invalid size #{size.inspect} for #{model}. Allowed: #{allowed.join(", ")}"
+    end
+
+    def legacy_options_to_new(options)
+      h = options.transform_keys { |k| k.to_sym }
+      if h.key?(:num_images)
+        h[:n] = h.delete(:num_images)
+      end
+      if h.key?(:response_format)
+        case h[:response_format].to_s
+        when "base64", "b64"
+          h[:response_format] = "b64_json"
+        end
+      end
+      h
+    end
+
+    class KeyOverride < SimpleDelegator
+      def initialize(base, api_key)
+        super(base)
+        @override_key = api_key
+      end
+
+      def resolved_api_key
+        s = @override_key.to_s
+        return s unless s.strip.empty?
+
+        __getobj__.resolved_api_key
+      end
+    end
+  end
+end

--- a/lib/generate_image/configuration.rb
+++ b/lib/generate_image/configuration.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module GenerateImage
+  class Configuration
+    attr_accessor :api_key, :default_model, :base_url, :default_size, :default_quality,
+                  :default_output_format, :open_timeout, :read_timeout, :max_retries
+
+    def initialize
+      @api_key = nil
+      @default_model = "gpt-image-1"
+      @base_url = "https://api.openai.com"
+      @default_size = "1024x1024"
+      @default_quality = "auto"
+      @default_output_format = "png"
+      @open_timeout = 30
+      @read_timeout = 120
+      @max_retries = 1
+    end
+
+    def resolved_api_key
+      [api_key, ENV["OPENAI_API_KEY"], ENV["DALL_E_API_KEY"]]
+        .compact
+        .map(&:to_s)
+        .find { |s| !s.strip.empty? }
+    end
+  end
+end

--- a/lib/generate_image/errors.rb
+++ b/lib/generate_image/errors.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module GenerateImage
+  class Error < StandardError; end
+
+  class AuthenticationError < Error; end
+
+  class RateLimitError < Error
+    attr_reader :retry_after
+
+    def initialize(message = nil, retry_after: 1)
+      super(message)
+      @retry_after = retry_after
+    end
+  end
+
+  class ApiError < Error
+    attr_reader :status_code, :body
+
+    def initialize(message = nil, status_code: nil, body: nil)
+      super(message)
+      @status_code = status_code
+      @body = body
+    end
+  end
+
+  class ValidationError < Error; end
+
+  # @deprecated Use {ApiError} instead. Kept for v1.x rescue compatibility.
+  RequestFailed = ApiError
+end

--- a/lib/generate_image/http.rb
+++ b/lib/generate_image/http.rb
@@ -1,0 +1,215 @@
+# frozen_string_literal: true
+
+require "json"
+require "net/http"
+require "securerandom"
+require "stringio"
+require "uri"
+
+module GenerateImage
+  class HTTP
+    def initialize(configuration:)
+      @configuration = configuration
+    end
+
+    def post_json(path, body_hash)
+      uri = build_uri(path)
+      body = JSON.generate(body_hash)
+
+      with_retries do
+        request = Net::HTTP::Post.new(uri)
+        request["Authorization"] = "Bearer #{api_key}"
+        request["Content-Type"] = "application/json"
+        request.body = body
+        perform(uri, request)
+      end
+    end
+
+    def post_multipart(path, fields, files)
+      uri = build_uri(path)
+      boundary = "----RubyGenerateImage#{SecureRandom.hex(16)}"
+      body = build_multipart_body(boundary, fields, files)
+
+      with_retries do
+        request = Net::HTTP::Post.new(uri)
+        request["Authorization"] = "Bearer #{api_key}"
+        request["Content-Type"] = "multipart/form-data; boundary=#{boundary}"
+        request.body = body
+        perform(uri, request)
+      end
+    end
+
+    private
+
+    attr_reader :configuration
+
+    def api_key
+      key = configuration.resolved_api_key
+      raise AuthenticationError, "Missing API key. Set OPENAI_API_KEY or configure api_key." if key.nil? || key.strip.empty?
+
+      key
+    end
+
+    def build_uri(path)
+      base = configuration.base_url.to_s.chomp("/")
+      URI.join("#{base}/", path.delete_prefix("/"))
+    end
+
+    def perform(uri, request)
+      http = Net::HTTP.new(uri.host, uri.port)
+      http.use_ssl = uri.scheme == "https"
+      http.open_timeout = configuration.open_timeout
+      http.read_timeout = configuration.read_timeout
+
+      response = http.request(request)
+      handle_response(response)
+    end
+
+    def handle_response(response)
+      case response.code.to_i
+      when 200, 201
+        parse_json_body(response.body)
+      when 401
+        raise AuthenticationError, error_message_from(response)
+      when 429
+        raise RateLimitError.new(
+          error_message_from(response),
+          retry_after: parse_retry_after(response["Retry-After"])
+        )
+      else
+        raise ApiError.new(error_message_from(response), status_code: response.code.to_i, body: response.body)
+      end
+    end
+
+    def parse_json_body(body)
+      return {} if body.nil? || body.empty?
+
+      JSON.parse(body)
+    rescue JSON::ParserError
+      raise ApiError.new("Invalid JSON response", body: body)
+    end
+
+    def error_message_from(response)
+      parsed = safe_parse_json(response.body)
+      err = parsed["error"]
+      if err.is_a?(Hash)
+        err["message"] || err.inspect
+      elsif err.is_a?(String)
+        err
+      else
+        "HTTP #{response.code}: #{response.message}"
+      end
+    rescue StandardError
+      "HTTP #{response.code}: #{response.message}"
+    end
+
+    def safe_parse_json(body)
+      return {} if body.nil? || body.empty?
+
+      JSON.parse(body)
+    rescue JSON::ParserError, TypeError
+      {}
+    end
+
+    def parse_retry_after(value)
+      s = value.to_s.strip
+      return 1 if s.empty?
+
+      if s.match?(/^\d+$/)
+        s.to_i.clamp(1, 120)
+      else
+        1
+      end
+    end
+
+    def with_retries
+      attempts = 0
+      max = [configuration.max_retries.to_i, 0].max
+
+      begin
+        yield
+      rescue RateLimitError => e
+        attempts += 1
+        raise e if attempts > max
+
+        sleep(e.retry_after.to_f.positive? ? e.retry_after : 1)
+        retry
+      end
+    end
+
+    def build_multipart_body(boundary, fields, files)
+      io = StringIO.new
+      crlf = "\r\n"
+
+      fields.each do |name, value|
+        next if value.nil?
+
+        io << "--#{boundary}#{crlf}"
+        io << "Content-Disposition: form-data; name=\"#{escape_name(name)}\"#{crlf}#{crlf}"
+        io << value.to_s
+        io << crlf
+      end
+
+      files.each do |name, file_spec|
+        filename, content, content_type = normalize_file_spec(name, file_spec)
+        io << "--#{boundary}#{crlf}"
+        io << "Content-Disposition: form-data; name=\"#{escape_name(name)}\"; filename=\"#{escape_filename(filename)}\"#{crlf}"
+        io << "Content-Type: #{content_type}#{crlf}#{crlf}"
+        io << content
+        io << crlf
+      end
+
+      io << "--#{boundary}--#{crlf}"
+      io.string
+    end
+
+    def escape_name(name)
+      name.to_s.gsub(/["\r\n]/, "")
+    end
+
+    def escape_filename(name)
+      name.to_s.gsub(/["\r\n]/, "")
+    end
+
+    def normalize_file_spec(name, spec)
+      case spec
+      when String
+        path = spec
+        [File.basename(path), File.binread(path), mime_for_path(path)]
+      when Pathname
+        path = spec.to_s
+        [File.basename(path), File.binread(path), mime_for_path(path)]
+      when Hash
+        filename = spec[:filename] || spec["filename"] || "image.png"
+        io = spec[:io] || spec["io"]
+        content_type = spec[:content_type] || spec["content_type"] || "application/octet-stream"
+        content =
+          if io.respond_to?(:read)
+            io.rewind if io.respond_to?(:rewind)
+            io.read
+          else
+            spec[:data] || spec["data"] || ""
+          end
+        [filename, content, content_type]
+      else
+        if spec.respond_to?(:read)
+          filename = spec.respond_to?(:path) && spec.path ? File.basename(spec.path) : "#{name}.png"
+          spec.rewind if spec.respond_to?(:rewind)
+          [filename, spec.read, "application/octet-stream"]
+        else
+          raise ValidationError, "Unsupported file payload for #{name}"
+        end
+      end
+    end
+
+    def mime_for_path(path)
+      case File.extname(path).downcase
+      when ".png" then "image/png"
+      when ".jpg", ".jpeg" then "image/jpeg"
+      when ".webp" then "image/webp"
+      when ".gif" then "image/gif"
+      else "application/octet-stream"
+      end
+    end
+  end
+end

--- a/lib/generate_image/models.rb
+++ b/lib/generate_image/models.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module GenerateImage
+  module Models
+    GPT_IMAGE = %w[gpt-image-1 gpt-image-1.5 gpt-image-1-mini].freeze
+    DALLE3 = "dall-e-3"
+    DALLE2 = "dall-e-2"
+
+    ALL = (GPT_IMAGE + [DALLE3, DALLE2]).freeze
+
+    GPT_IMAGE_SIZES = %w[auto 1024x1024 1536x1024 1024x1536].freeze
+    DALLE3_SIZES = %w[1024x1024 1792x1024 1024x1792].freeze
+    DALLE2_SIZES = %w[256x256 512x512 1024x1024].freeze
+
+    GPT_IMAGE_QUALITIES = %w[auto high medium low].freeze
+    DALLE3_QUALITIES = %w[standard hd].freeze
+
+    OUTPUT_FORMATS = %w[png jpeg webp].freeze
+
+    module_function
+
+    def gpt_image?(model)
+      GPT_IMAGE.include?(model.to_s)
+    end
+
+    def dall_e_3?(model)
+      model.to_s == DALLE3
+    end
+  end
+end

--- a/lib/generate_image/response.rb
+++ b/lib/generate_image/response.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+module GenerateImage
+  class Response
+    attr_reader :raw, :model
+
+    def initialize(parsed_json, model: nil)
+      @raw = parsed_json
+      @model = model
+    end
+
+    def data_items
+      Array(raw["data"])
+    end
+
+    def images
+      data_items.map do |item|
+        if item["url"]
+          { url: item["url"] }
+        elsif item["b64_json"]
+          { b64_json: item["b64_json"] }
+        else
+          {}
+        end
+      end
+    end
+
+    def url
+      data_items.find { |d| d["url"] }&.fetch("url", nil)
+    end
+
+    def b64
+      data_items.find { |d| d["b64_json"] }&.fetch("b64_json", nil)
+    end
+
+    def usage
+      raw["usage"]
+    end
+
+    def created
+      raw["created"]
+    end
+
+    def to_h
+      if url
+        { image_url: url }
+      elsif b64
+        { image_base64: b64 }
+      else
+        {}
+      end
+    end
+  end
+end

--- a/lib/generate_image/version.rb
+++ b/lib/generate_image/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module GenerateImage
-  VERSION = "1.1.2.1"
+  VERSION = "2.0.0"
 end

--- a/spec/generate_image/client_spec.rb
+++ b/spec/generate_image/client_spec.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+require "json"
+require "tempfile"
+
+RSpec.describe GenerateImage::Client do
+  let(:client) { described_class.new("sk-test") }
+
+  describe "#generate" do
+    it "calls generations with GPT Image defaults" do
+      stub_request(:post, "https://api.openai.com/v1/images/generations")
+        .with do |req|
+          b = JSON.parse(req.body)
+          b["prompt"] == "a ruby gemstone" &&
+            b["model"] == "gpt-image-1" &&
+            b["size"] == "1024x1024" &&
+            b["quality"] == "auto" &&
+            b["output_format"] == "png"
+        end
+        .to_return(status: 200, body: {
+          data: [{ b64_json: "AAA" }],
+          usage: { total_tokens: 10 }
+        }.to_json)
+
+      res = client.generate("a ruby gemstone")
+      expect(res.b64).to eq("AAA")
+      expect(res.usage["total_tokens"]).to eq(10)
+    end
+
+    it "maps DALL-E 3 params" do
+      stub_request(:post, "https://api.openai.com/v1/images/generations")
+        .with do |req|
+          b = JSON.parse(req.body)
+          b["model"] == "dall-e-3" && b["quality"] == "hd" && b["response_format"] == "url"
+        end
+        .to_return(status: 200, body: { data: [{ url: "https://cdn.example/x.png" }] }.to_json)
+
+      res = client.generate("sunset", model: "dall-e-3", quality: "hd", size: "1792x1024")
+      expect(res.url).to eq("https://cdn.example/x.png")
+    end
+
+    it "rejects invalid size for model" do
+      expect do
+        client.generate("x", model: "dall-e-3", size: "1024x1536")
+      end.to raise_error(GenerateImage::ValidationError, /Invalid size/)
+    end
+
+    it "rejects n > 1 for dall-e-3" do
+      expect do
+        client.generate("x", model: "dall-e-3", n: 2)
+      end.to raise_error(GenerateImage::ValidationError, /n must be 1/)
+    end
+  end
+
+  describe "#edit" do
+    it "posts multipart to edits" do
+      stub_request(:post, "https://api.openai.com/v1/images/edits")
+        .with { |req| req.body.include?("edit mask") && req.body.include?('name="image"') }
+        .to_return(status: 200, body: { data: [{ b64_json: "EDIT" }] }.to_json)
+
+      tmp = Tempfile.new(["in", ".png"])
+      tmp.binmode
+      tmp.write("fakepng")
+      tmp.close
+
+      res = client.edit(image: tmp.path, prompt: "edit mask", model: "gpt-image-1")
+      expect(res.b64).to eq("EDIT")
+    ensure
+      tmp&.unlink
+    end
+  end
+
+  describe "#generate_image (deprecated)" do
+    it "delegates to #generate and returns legacy hash" do
+      stub_request(:post, "https://api.openai.com/v1/images/generations")
+        .to_return(status: 200, body: { data: [{ url: "https://legacy" }] }.to_json)
+
+      expect do
+        h = client.generate_image("old api", { response_format: "url" })
+        expect(h).to eq({ image_url: "https://legacy" })
+      end.to output(/DEPRECATION/).to_stderr
+    end
+
+    it "maps num_images and base64 response_format" do
+      stub_request(:post, "https://api.openai.com/v1/images/generations")
+        .with do |req|
+          JSON.parse(req.body)["n"] == 2 && JSON.parse(req.body)["response_format"] == "b64_json"
+        end
+        .to_return(status: 200, body: { data: [{ b64_json: "BBB" }] }.to_json)
+
+      expect do
+        h = client.generate_image("x", num_images: 2, response_format: "base64")
+        expect(h).to eq({ image_base64: "BBB" })
+      end.to output(/DEPRECATION/).to_stderr
+    end
+  end
+
+  describe "env key resolution" do
+    it "uses DALL_E_API_KEY when OPENAI_API_KEY unset" do
+      ENV["DALL_E_API_KEY"] = "from-dalle"
+      c = described_class.new
+      stub_request(:post, "https://api.openai.com/v1/images/generations")
+        .with(headers: { "Authorization" => "Bearer from-dalle" })
+        .to_return(status: 200, body: { data: [{ url: "https://u" }] }.to_json)
+
+      expect(c.generate("p").url).to eq("https://u")
+    end
+  end
+end

--- a/spec/generate_image/configuration_spec.rb
+++ b/spec/generate_image/configuration_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+RSpec.describe GenerateImage::Configuration do
+  describe "#resolved_api_key" do
+    it "prefers explicit api_key" do
+      ENV["OPENAI_API_KEY"] = "openai"
+      ENV["DALL_E_API_KEY"] = "dalle"
+      c = described_class.new
+      c.api_key = "explicit"
+      expect(c.resolved_api_key).to eq("explicit")
+    end
+
+    it "falls back to OPENAI_API_KEY then DALL_E_API_KEY" do
+      ENV["DALL_E_API_KEY"] = "dalle"
+      expect(described_class.new.resolved_api_key).to eq("dalle")
+
+      ENV["OPENAI_API_KEY"] = "openai"
+      expect(described_class.new.resolved_api_key).to eq("openai")
+    end
+  end
+
+  describe "defaults" do
+    it "matches 2026-oriented defaults" do
+      c = described_class.new
+      expect(c.default_model).to eq("gpt-image-1")
+      expect(c.base_url).to eq("https://api.openai.com")
+      expect(c.default_size).to eq("1024x1024")
+      expect(c.default_quality).to eq("auto")
+      expect(c.default_output_format).to eq("png")
+    end
+  end
+end

--- a/spec/generate_image/http_spec.rb
+++ b/spec/generate_image/http_spec.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require "json"
+require "tempfile"
+
+RSpec.describe GenerateImage::HTTP do
+  let(:configuration) do
+    c = GenerateImage::Configuration.new
+    c.api_key = "sk-test"
+    c.base_url = "https://api.openai.com"
+    c.max_retries = 1
+    c
+  end
+
+  let(:http) { described_class.new(configuration: configuration) }
+
+  describe "#post_json" do
+    it "posts JSON and returns parsed body" do
+      stub_request(:post, "https://api.openai.com/v1/images/generations")
+        .with(
+          body: '{"prompt":"hi","model":"gpt-image-1"}',
+          headers: { "Authorization" => "Bearer sk-test", "Content-Type" => "application/json" }
+        )
+        .to_return(status: 200, body: { data: [] }.to_json, headers: { "Content-Type" => "application/json" })
+
+      result = http.post_json("/v1/images/generations", { prompt: "hi", model: "gpt-image-1" })
+      expect(result["data"]).to eq([])
+    end
+
+    it "raises AuthenticationError on 401" do
+      stub_request(:post, "https://api.openai.com/v1/x")
+        .to_return(status: 401, body: { error: { message: "bad" } }.to_json)
+
+      expect do
+        http.post_json("/v1/x", {})
+      end.to raise_error(GenerateImage::AuthenticationError, /bad/)
+    end
+
+    it "retries on 429 then succeeds" do
+      stub_request(:post, "https://api.openai.com/v1/images/generations")
+        .to_return({ status: 429, headers: { "Retry-After" => "0" } },
+                   { status: 200, body: { ok: true }.to_json, headers: { "Content-Type" => "application/json" } })
+
+      result = http.post_json("/v1/images/generations", { prompt: "x", model: "gpt-image-1" })
+      expect(result["ok"]).to be true
+    end
+  end
+
+  describe "#post_multipart" do
+    it "sends multipart with file field" do
+      stub_request(:post, "https://api.openai.com/v1/images/edits")
+        .with { |req|
+          req.body.include?('name="prompt"') &&
+            req.body.include?('name="image"') &&
+            req.headers["Content-Type"].start_with?("multipart/form-data; boundary=")
+        }
+        .to_return(status: 200, body: { data: [{ b64_json: "qqq" }] }.to_json)
+
+      tmp = Tempfile.new(["img", ".png"])
+      tmp.binmode
+      tmp.write("\x89PNG\r\n\x1a\n")
+      tmp.close
+
+      result = http.post_multipart(
+        "/v1/images/edits",
+        { "model" => "gpt-image-1", "prompt" => "edit me", "n" => "1", "size" => "1024x1024" },
+        { "image" => tmp.path }
+      )
+      expect(result["data"].first["b64_json"]).to eq("qqq")
+    ensure
+      tmp&.unlink
+    end
+  end
+end

--- a/spec/generate_image/response_spec.rb
+++ b/spec/generate_image/response_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+RSpec.describe GenerateImage::Response do
+  describe "#url, #b64, #images, #usage" do
+    it "parses URL responses" do
+      raw = {
+        "created" => 1,
+        "data" => [{ "url" => "https://example.com/a.png" }]
+      }
+      r = described_class.new(raw, model: "dall-e-3")
+      expect(r.url).to eq("https://example.com/a.png")
+      expect(r.b64).to be_nil
+      expect(r.images).to eq([{ url: "https://example.com/a.png" }])
+      expect(r.usage).to be_nil
+      expect(r.model).to eq("dall-e-3")
+    end
+
+    it "parses base64 responses" do
+      raw = { "data" => [{ "b64_json" => "abc" }] }
+      r = described_class.new(raw)
+      expect(r.b64).to eq("abc")
+      expect(r.url).to be_nil
+      expect(r.images).to eq([{ b64_json: "abc" }])
+    end
+
+    it "exposes usage when present" do
+      raw = {
+        "data" => [{ "b64_json" => "x" }],
+        "usage" => { "input_tokens" => 1, "output_tokens" => 2, "total_tokens" => 3 }
+      }
+      r = described_class.new(raw)
+      expect(r.usage["total_tokens"]).to eq(3)
+    end
+  end
+
+  describe "#to_h" do
+    it "returns legacy-compatible hash" do
+      raw = { "data" => [{ "url" => "https://x.test" }] }
+      expect(described_class.new(raw).to_h).to eq({ image_url: "https://x.test" })
+    end
+  end
+end

--- a/spec/generate_image_spec.rb
+++ b/spec/generate_image_spec.rb
@@ -1,9 +1,0 @@
-RSpec.describe GenerateImage do
-  it "has a version number" do
-    expect(GenerateImage::VERSION).not_to be nil
-  end
-
-  it "does something useful" do
-    expect(false).to eq(true)
-  end
-end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,14 +1,23 @@
+# frozen_string_literal: true
+
 require "bundler/setup"
+require "webmock/rspec"
 require "generate_image"
 
-RSpec.configure do |config|
-  # Enable flags like --only-failures and --next-failure
-  config.example_status_persistence_file_path = ".rspec_status"
+WebMock.disable_net_connect!(allow_localhost: true)
 
-  # Disable RSpec exposing methods globally on `Module` and `main`
+RSpec.configure do |config|
+  config.example_status_persistence_file_path = ".rspec_status"
   config.disable_monkey_patching!
 
   config.expect_with :rspec do |c|
     c.syntax = :expect
+  end
+
+  config.before do
+    WebMock.reset!
+    ENV.delete("OPENAI_API_KEY")
+    ENV.delete("DALL_E_API_KEY")
+    GenerateImage.instance_variable_set(:@configuration, GenerateImage::Configuration.new)
   end
 end


### PR DESCRIPTION
- Replace DALL-E 2 defaults with GPT Image (gpt-image-1) and stdlib HTTP
- Add Client#generate, #edit, Configuration, Response, error types
- Add WebMock RSpec suite, CI workflow, CHANGELOG and docs
- Deprecate #generate_image; keep DALL_E_API_KEY fallback

Made-with: Cursor